### PR TITLE
Y9S4 - Mid Season Patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1956,9 +1956,9 @@
       "devOptional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",

--- a/src/data/operators.json
+++ b/src/data/operators.json
@@ -169,7 +169,7 @@
       "name": "Glaz",
       "loadout": {
         "primary": [
-          "DMR"
+          "SR"
         ],
         "secondary": [
           "HG",
@@ -613,7 +613,7 @@
       "name": "Kali",
       "loadout": {
         "primary": [
-          "DMR"
+          "SR"
         ],
         "secondary": [
           "MP",

--- a/src/data/operators.json
+++ b/src/data/operators.json
@@ -46,7 +46,7 @@
         "BREACH",
         "ANTIGADGET"
       ],
-      "speed": 1,
+      "speed": 2,
       "squad": "REDHAMMER"
     },
     "THATCHER": {
@@ -270,7 +270,7 @@
         ],
         "gadgets": [
           "STUN",
-          "HARDBREACH"
+          "CLAYMORE"
         ]
       },
       "roles": [
@@ -824,8 +824,7 @@
           "LMG"
         ],
         "secondary": [
-          "HG",
-          "SG"
+          "HG"
         ],
         "gadgets": [
           "STUN",
@@ -1043,7 +1042,7 @@
         ],
         "gadgets": [
           "CAMERA",
-          "C4"
+          "BARBED"
         ]
       },
       "roles": [

--- a/src/data/playlists.json
+++ b/src/data/playlists.json
@@ -144,7 +144,7 @@
       ]
     },
     "DEATHMATCH": {
-      "name": "Deathmatch",
+      "name": "Team Deathmatch",
       "maps": [
         "CONSULATE",
         "LAIR",

--- a/src/data/playlists.json
+++ b/src/data/playlists.json
@@ -14,6 +14,15 @@
         "LAIR"
       ]
     },
+    "CUP": {
+      "name": "Siege Cup",
+      "maps": [
+        "CONSULATE",
+        "BORDER",
+        "CHALET",
+        "SKYSCRAPER"
+      ]
+    },
     "RANKED": {
       "name": "Ranked",
       "maps": [
@@ -59,10 +68,10 @@
         "FORTRESS",
         "OUTBACK",
         "EMERALD",
+        "BRAVO",
         "LABS",
         "LAIR",
-        "ALPHA",
-        "BRAVO"
+        "ALPHA"
       ]
     }
   },
@@ -77,8 +86,11 @@
         "PLANE",
         "CONSULATE",
         "BANK",
+        "KANAL",
         "CHALET",
+        "KAFE",
         "YACHT",
+        "BORDER",
         "FAVELA",
         "SKYSCRAPER",
         "COASTLINE",
@@ -86,11 +98,12 @@
         "TOWER",
         "VILLA",
         "FORTRESS",
+        "OUTBACK",
         "EMERALD",
+        "BRAVO",
         "LABS",
         "LAIR",
-        "ALPHA",
-        "BRAVO"
+        "ALPHA"
       ]
     }
   },
@@ -99,29 +112,29 @@
       "name": "Weapon Roulette",
       "maps": [
         "CLOSEQUARTER",
+        "COASTLINE",
+        "FAVELA",
+        "LABS",
+        "THEMEPARK",
+        "LAIR",
         "ALPHA",
         "BRAVO",
-        "FAVELA",
-        "COASTLINE",
-        "OUTBACK",
-        "THEMEPARK",
-        "LABS",
-        "LAIR"
+        "OUTBACK"
       ]
     },
     "F4A": {
       "name": "Free for All",
       "maps": [
         "CLOSEQUARTER",
+        "LABS",
+        "CONSULATE",
+        "VILLA",
+        "THEMEPARK",
+        "LAIR",
         "ALPHA",
         "BORDER",
         "OREGON",
-        "COASTLINE",
-        "VILLA",
-        "THEMEPARK",
-        "LABS",
-        "CONSULATE",
-        "LAIR"
+        "COASTLINE"
       ],
       "operators": [
         "!MONTAGNE",
@@ -132,16 +145,16 @@
     "DEATHMATCH": {
       "name": "Deathmatch",
       "maps": [
+        "CONSULATE",
+        "LAIR",
+        "SKYSCRAPER",
         "CLOSEQUARTER",
+        "THEMEPARK",
+        "VILLA",
+        "LABS",
         "ALPHA",
         "BORDER",
-        "CLUBHOUSE",
-        "SKYSCRAPER",
-        "VILLA",
-        "THEMEPARK",
-        "LABS",
-        "CONSULATE",
-        "LAIR"
+        "CLUBHOUSE"
       ],
       "operators": [
         "!MONTAGNE",
@@ -149,34 +162,18 @@
         "!CLASH"
       ]
     },
-    "SNIPERS": {
-      "name": "Snipers Only",
-      "maps": [
-        "HEREFORD"
-      ]
-    },
     "GOLDENGUN": {
       "name": "Golden Gun",
       "maps": [
         "CLOSEQUARTER",
-        "ALPHA",
         "BRAVO",
         "FAVELA",
-        "COASTLINE",
-        "OUTBACK",
         "EMERALD",
         "SKYSCRAPER",
-        "LAIR"
-      ]
-    },
-    "HEADSHOTS": {
-      "name": "Headshots Only",
-      "maps": [
+        "LAIR",
+        "ALPHA",
         "COASTLINE",
-        "THEMEPARK",
-        "VILLA",
-        "CLOSEQUARTER",
-        "LABS"
+        "OUTBACK"
       ]
     }
   },

--- a/src/data/playlists.json
+++ b/src/data/playlists.json
@@ -139,6 +139,7 @@
       "operators": [
         "!MONTAGNE",
         "!BLITZ",
+        "!BLACKBEARD",
         "!CLASH"
       ]
     },
@@ -159,6 +160,7 @@
       "operators": [
         "!MONTAGNE",
         "!BLITZ",
+        "!BLACKBEARD",
         "!CLASH"
       ]
     },

--- a/src/data/playlists.json
+++ b/src/data/playlists.json
@@ -143,7 +143,7 @@
         "!CLASH"
       ]
     },
-    "DEATHMATCH": {
+    "TDM": {
       "name": "Team Deathmatch",
       "maps": [
         "CONSULATE",

--- a/src/data/weaponClasses.json
+++ b/src/data/weaponClasses.json
@@ -22,6 +22,10 @@
     "name": "Marksman Rifle",
     "slot": "PRIMARY"
   },
+  "SR": {
+    "name": "Sniper Rifle",
+    "slot": "PRIMARY"
+  },
   "MP": {
     "name": "Machine Pistol",
     "slot": "SECONDARY"


### PR DESCRIPTION
# Y9S4 - Mid Season Patch

### Operators

* Updated Sledge to 2 speed
* Updated various loadouts

### Playlists

* Added Siege Cup playlist
* Removed Headshot Only and Sniper Only playlists, as they are neither active nor available to play in Custom matches
* Updated Deathmatch playlist name to Team Deathmatch and key to TDM
* Added missing maps to Quickmatch playlist
* Updated map order in several playlists
* Banned Blackbeard from Free for All and Team Deathmatch playlists

### Weapons

* Added Sniper Rifle weapon class for Kali and Glaz

### Technical

* Package updates